### PR TITLE
fix: wrap parseGMResponse in try/catch in onload

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,11 @@ function XHR(request: Request, init: RequestInit | undefined, data: string | und
       data: data,
       responseType: "blob",
       onload(res) {
-        resolve(parseGMResponse(request, res));
+        try {
+          resolve(parseGMResponse(request, res));
+        } catch (e) {
+          reject(e);
+        }
       },
       onabort() {
         reject(new DOMException("Aborted", "AbortError"));


### PR DESCRIPTION
This change ensures synchronous errors (e.g., "body.stream is not a function") are caught  and properly passed to reject, instead of bubbling up outside the promise.

 <!--
close # 
-->
